### PR TITLE
Adding option to provide listfiles to the 'extract' and 'list' commmands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://img.shields.io/github/actions/workflow/status/TheGrayDot/mpqcli/tag.yml?style=flat) ![Release](https://img.shields.io/github/v/release/TheGrayDot/mpqcli?style=flat) ![Downloads](https://img.shields.io/github/downloads/TheGrayDot/mpqcli/total?style=flat)
 
-A command line tool to read, extract, search, create and verify MPQ files using the StormLib library
+A command line tool to read, extract, search, create and verify MPQ files using the [StormLib library](https://github.com/ladislav-zezula/StormLib).
 
 ## Overview
 
@@ -72,6 +72,14 @@ Extract files to a specific target directory - which will be created if it doesn
 mpqcli extract -o /path/to/target/directory <target_mpq_file>
 ```
 
+### Extract all files with an external listfile
+
+Older MPQ archives do not contain (complete) file paths of their content. By providing an external listfile that lists the content of the MPQ archive, the extracted files will have the correct names and paths. Listfiles can be downloaded on [Ladislav Zezula's site](http://www.zezula.net/en/mpq/download.html).
+
+```
+mpqcli extract -l /path/to/listfile <target_mpq_file>
+```
+
 ### Extract one specific file
 
 Extract a single file using the `-f` option. If the target file in the MPQ archive is nested (in a directory) you need to include the full path. Similar to examples above, you can use the `-o` argument to specify the output directory.
@@ -86,6 +94,14 @@ Pretty simple, list files in an MPQ archive. Useful to "pipe" to other tools, su
 
 ```
 mpqcli list <target_mpq_file>
+```
+
+### List all files with an external listfile
+
+Older MPQ archives do not contain (complete) file paths of their content. By providing an external listfile that lists the content of the MPQ archive, the listed files will have the correct paths. Listfiles can be downloaded on [Ladislav Zezula's site](http://www.zezula.net/en/mpq/download.html).
+
+```
+mpqcli list -l /path/to/listfile <target_mpq_file>
 ```
 
 ### Search and extract files on Linux

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ int main(int argc, char **argv) {
     bool keepFolderStructure = false;
     bool patchExtractBin = false;
     std::string extractFileName = "default";
+    std::string listfileName = "";
     int32_t mpqVersion = 1;
 
     // Subcommand: Version
@@ -38,6 +39,9 @@ int main(int argc, char **argv) {
     extract->add_option("-o,--output", output, "Output directory");
     extract->add_option("-f,--file", extractFileName, "Target file to extract");
     extract->add_flag("-k,--keep", keepFolderStructure, "Keep folder structure (default false)");
+    extract->add_option("-l,--listfile", listfileName, "File listing content of MPQ")
+        ->check(CLI::ExistingFile);
+
 
     // Subcommand: Create
     CLI::App *create = app.add_subcommand("create", "Create MPQ file from target directory");
@@ -51,6 +55,8 @@ int main(int argc, char **argv) {
     CLI::App *list = app.add_subcommand("list", "List files from the MPQ file");
     list->add_option("target", target, "Target MPQ file")
         ->required()
+        ->check(CLI::ExistingFile);
+    list->add_option("-l,--listfile", listfileName, "File listing content of MPQ")
         ->check(CLI::ExistingFile);
 
     // Subcommand: Verify
@@ -97,7 +103,7 @@ int main(int argc, char **argv) {
         if (extractFileName != "default") {
             ExtractFile(hArchive, output, extractFileName, keepFolderStructure);
         } else {
-            ExtractFiles(hArchive, output);
+            ExtractFiles(hArchive, output, listfileName);
         }
     }
 
@@ -135,7 +141,7 @@ int main(int argc, char **argv) {
     if (app.got_subcommand(list)) {
         HANDLE hArchive;
         OpenMpqArchive(target, &hArchive);
-        ListFiles(hArchive);
+        ListFiles(hArchive, listfileName);
         return 1;
     }
 

--- a/src/mpq.cpp
+++ b/src/mpq.cpp
@@ -18,9 +18,10 @@ int OpenMpqArchive(const std::string &filename, HANDLE *hArchive) {
     return 1;
 }
 
-int ExtractFiles(HANDLE hArchive, const std::string& output) {
+int ExtractFiles(HANDLE hArchive, const std::string& output, const std::string& listfileName) {
     SFILE_FIND_DATA findData;
-    HANDLE findHandle = SFileFindFirstFile(hArchive, "*", &findData, NULL);
+    const char *listfile = listfileName.empty() ? NULL : listfileName.c_str();
+    HANDLE findHandle = SFileFindFirstFile(hArchive, "*", &findData, listfile);
     if (findHandle == NULL) {
         std::cerr << "[+] Failed to find first file in MPQ archive." << std::endl;
         SFileCloseArchive(hArchive);
@@ -84,7 +85,7 @@ int ExtractFile(HANDLE hArchive, const std::string& output, const std::string& f
         std::cerr << "[+] Failed: " << "(" << error << ") " << szFileName << std::endl;
         return error;
     }
- 
+
     return 0;
 }
 
@@ -120,7 +121,7 @@ int CreateMpqArchive(std::string inputTargetDirectory, int32_t mpqVersion) {
     }
     // Add 2 more for listfile and attributes
     fileCount = fileCount + 3;
-    
+
     HANDLE hMpq;
     bool result = SFileCreateArchive(
         outputPath.c_str(),
@@ -128,7 +129,7 @@ int CreateMpqArchive(std::string inputTargetDirectory, int32_t mpqVersion) {
         fileCount,
         &hMpq
     );
-    
+
     if (!result) {
         std::cerr << "[+] Failed to create MPQ archive." << std::endl;
         int32_t error = GetLastError();
@@ -189,10 +190,11 @@ int CreateMpqArchive(std::string inputTargetDirectory, int32_t mpqVersion) {
     return 0;
 }
 
-int ListFiles(HANDLE hArchive) {
+int ListFiles(HANDLE hArchive, const std::string& listfileName) {
     // Find the first file in MPQ archive to iterate from
     SFILE_FIND_DATA findData;
-    HANDLE findHandle = SFileFindFirstFile(hArchive, "*", &findData, NULL);
+    const char *listfile = listfileName.empty() ? NULL : listfileName.c_str();
+    HANDLE findHandle = SFileFindFirstFile(hArchive, "*", &findData, listfile);
     if (findHandle == NULL) {
         std::cerr << "[+] Failed to find first file in MPQ archive." << std::endl;
         SFileCloseArchive(hArchive);

--- a/src/mpq.h
+++ b/src/mpq.h
@@ -5,10 +5,10 @@
 #include <StormLib.h>
 
 int OpenMpqArchive(const std::string &filename, HANDLE *hArchive);
-int ExtractFiles(HANDLE hArchive, const std::string& output);
+int ExtractFiles(HANDLE hArchive, const std::string& output, const std::string &listfileName);
 int ExtractFile(HANDLE hArchive, const std::string& output, const std::string& fileName, bool keepFolderStructure);
 int CreateMpqArchive(std::string inputPath, int32_t mpqVersion);
-int ListFiles(HANDLE hHandle);
+int ListFiles(HANDLE hHandle, const std::string &listfileName);
 char* ReadFile(HANDLE hArchive, const char *szFileName, unsigned int *fileSize);
 
 void PrintMpqInfo(HANDLE hArchive);


### PR DESCRIPTION
The MPQ file format don't contain the file names of the files in the archives. By convention, the file names tend to be listed in the file `(listfile)`, but in older MPQs (from StarCraft I, WarCraft II BNE, Diablo I, etc) that file is missing or incomplete.

By providing an external listfile, the user can list or extract files under their correct file paths.

This PR works by setting the `szListFile` argument of the [SFileFindFirstFile function](https://www.zezula.net/en/mpq/stormlib/sfilefindfirstfile.html) to the path given by the user.