### PR TITLE
Feat: Add optional --path argument to add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ echo "For The Horde!" > fth.txt
 mpqcli add fth.txt wow-patch.mpq
 ```
 
+Alternatively, you can add a file to a specific subdirectory using the `-p` or `--path` argument.
+
+```
+echo "For The Alliance!" > fta.txt
+mpqcli add fta.txt wow-patch.mpq --path <path/in/archive>
+```
+
 ### Remove a file from an existing archive
 
 Remove a file from an existing MPQ archive.

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -92,15 +92,18 @@ int32_t CalculateMpqMaxFileValue(const std::string &directory) {
         return 32;
     }
 
-    fileCount--;
-    fileCount |= fileCount >> 1;
-    fileCount |= fileCount >> 2;
-    fileCount |= fileCount >> 4;
-    fileCount |= fileCount >> 8;
-    fileCount |= fileCount >> 16;
-    fileCount++;
+    return NextPowerOfTwo(fileCount);
+}
 
-    return fileCount;
+int32_t NextPowerOfTwo(int32_t n)
+{
+    n--;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    return n + 1;
 }
 
 void PrintAsBinary(const char* buffer, uint32_t size) {

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -11,6 +11,7 @@ std::string LocaleToLang(uint16_t locale);
 std::string NormalizeFilePath(const fs::path &path);
 std::string WindowsifyFilePath(const fs::path &path);
 int32_t CalculateMpqMaxFileValue(const std::string &directory);
+int32_t NextPowerOfTwo(int32_t n);
 void PrintAsBinary(const char* buffer, uint32_t size);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     add->add_option("target", baseTarget, "Target MPQ archive")
         ->required()
         ->check(CLI::ExistingFile);
-    add->add_option("--path", basePath, "Path within MPQ archive");
+    add->add_option("-p,--path", basePath, "Path within MPQ archive");
 
     // Subcommand: Remove
     CLI::App *remove = app.add_subcommand("remove", "Remove file from an existing MPQ archive");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
         // Optional: specified path inside archive
         if (basePath != "default") {
             fs::path archiveFullPath = fs::path(basePath) / filePath.filename();
-            archivePath = archiveFullPath.generic_u8string();
+            archivePath = archiveFullPath.u8string();
         }
 
         AddFile(hArchive, baseFile, archivePath);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,10 +196,10 @@ int main(int argc, char **argv) {
         // File on disk
         fs::path fileNamePath = fs::path(baseFile);
 
-        // Default: just the filename
+        // Default: use the filename as path, saves file to root of MPQ
         std::string archivePath = fileNamePath.filename().u8string();
 
-        // Optional: user-specified path inside archive
+        // Optional: specified path inside archive
         if (basePath != "default") {
             fs::path archiveFullPath = fs::path(basePath) / fileNamePath.filename();
             archivePath = archiveFullPath.generic_u8string();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
             archivePath = archiveFullPath.generic_u8string();
         }
 
-        AddFile(hArchive, fileNamePath.u8string(), archivePath);
+        AddFile(hArchive, baseFile, archivePath);
         CloseMpqArchive(hArchive);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,7 +202,9 @@ int main(int argc, char **argv) {
         // Optional: specified path inside archive
         if (basePath != "default") {
             fs::path archiveFullPath = fs::path(basePath) / filePath.filename();
-            archivePath = archiveFullPath.u8string();
+
+            // Normalise path for MPQ
+            archivePath = WindowsifyFilePath(archiveFullPath.u8string());
         }
 
         AddFile(hArchive, baseFile, archivePath);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,9 +205,6 @@ int main(int argc, char **argv) {
             archivePath = archiveFullPath.generic_u8string();
         }
 
-        std::cout << "[+] Adding: " << fileNamePath.u8string()
-            << " as " << archivePath << std::endl;
-
         AddFile(hArchive, fileNamePath.u8string(), archivePath);
         CloseMpqArchive(hArchive);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,15 +193,15 @@ int main(int argc, char **argv) {
             return 1;
         }
 
-        // File on disk
-        fs::path fileNamePath = fs::path(baseFile);
+        // Path to file on disk
+        fs::path filePath = fs::path(baseFile);
 
         // Default: use the filename as path, saves file to root of MPQ
-        std::string archivePath = fileNamePath.filename().u8string();
+        std::string archivePath = filePath.filename().u8string();
 
         // Optional: specified path inside archive
         if (basePath != "default") {
-            fs::path archiveFullPath = fs::path(basePath) / fileNamePath.filename();
+            fs::path archiveFullPath = fs::path(basePath) / filePath.filename();
             archivePath = archiveFullPath.generic_u8string();
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ int main(int argc, char **argv) {
     // These are reused in multiple subcommands
     std::string baseTarget = "default";  // all subcommands
     std::string baseFile = "default";  // add, remove, extract, read
+    std::string basePath = "default"; // add
     std::string baseOutput = "default";  // create, extract
     std::string baseListfileName = "default";  // list, extract
     // CLI: info
@@ -78,6 +79,7 @@ int main(int argc, char **argv) {
     add->add_option("target", baseTarget, "Target MPQ archive")
         ->required()
         ->check(CLI::ExistingFile);
+    add->add_option("--path", basePath, "Path within MPQ archive");
 
     // Subcommand: Remove
     CLI::App *remove = app.add_subcommand("remove", "Remove file from an existing MPQ archive");
@@ -191,11 +193,22 @@ int main(int argc, char **argv) {
             return 1;
         }
 
-        // Save the file to root of MPQ archive
+        // File on disk
         fs::path fileNamePath = fs::path(baseFile);
-        std::string fileNameString = fileNamePath.filename().u8string();
 
-        AddFile(hArchive, baseFile, fileNameString);
+        // Default: just the filename
+        std::string archivePath = fileNamePath.filename().u8string();
+
+        // Optional: user-specified path inside archive
+        if (basePath != "default") {
+            fs::path archiveFullPath = fs::path(basePath) / fileNamePath.filename();
+            archivePath = archiveFullPath.generic_u8string();
+        }
+
+        std::cout << "[+] Adding: " << fileNamePath.u8string()
+            << " as " << archivePath << std::endl;
+
+        AddFile(hArchive, fileNamePath.u8string(), archivePath);
         CloseMpqArchive(hArchive);
     }
 

--- a/src/mpq.cpp
+++ b/src/mpq.cpp
@@ -205,7 +205,7 @@ int AddFile(HANDLE hArchive, fs::path localFile, const std::string& archiveFileP
 
     // Set file attributes in MPQ archive (compression and encryption)
     DWORD dwFlags = MPQ_FILE_COMPRESS | MPQ_FILE_ENCRYPTED;
-    DWORD dwCompression = MPQ_COMPRESSION_ZLIB; 
+    DWORD dwCompression = MPQ_COMPRESSION_ZLIB;
 
     bool addedFile = SFileAddFileEx(
         hArchive,


### PR DESCRIPTION
Referencing https://github.com/TheGrayDot/mpqcli/issues/103

Tested on Windows, path can be specified as ```path\within\mpq\``` (with or without trailing slash) using the ```-p``` or ```--path``` optional argument for ```add```.

Probably requires some additional changes, but file is added as intended to the archive at the correct directory/subdirectory.