### PR TITLE
Adding support for locales

### DIFF
--- a/src/helpers.h
+++ b/src/helpers.h
@@ -8,6 +8,7 @@ namespace fs = std::filesystem;
 
 std::string FileTimeToLsTime(int64_t fileTime);
 std::string LocaleToLang(uint16_t locale);
+LCID LangToLocale(const std::string &lang);
 std::string NormalizeFilePath(const fs::path &path);
 std::string WindowsifyFilePath(const fs::path &path);
 int32_t CalculateMpqMaxFileValue(const std::string &directory);

--- a/src/mpq.h
+++ b/src/mpq.h
@@ -7,18 +7,19 @@
 #include <StormLib.h>
 
 namespace fs = std::filesystem;
+const LCID defaultLocale = 0;
 
 int OpenMpqArchive(const std::string &filename, HANDLE *hArchive, int32_t flags);
 int CloseMpqArchive(HANDLE hArchive);
 int SignMpqArchive(HANDLE hArchive);
-int ExtractFiles(HANDLE hArchive, const std::string& output, const std::string &listfileName);
-int ExtractFile(HANDLE hArchive, const std::string& output, const std::string& fileName, bool keepFolderStructure);
+int ExtractFiles(HANDLE hArchive, const std::string& output, const std::string &listfileName, LCID preferredLocale);
+int ExtractFile(HANDLE hArchive, const std::string& output, const std::string& fileName, bool keepFolderStructure, LCID preferredLocale);
 HANDLE CreateMpqArchive(std::string outputArchiveName, int32_t fileCount, int32_t mpqVersion);
-int AddFiles(HANDLE hArchive, const std::string& inputPath);
-int AddFile(HANDLE hArchive, fs::path localFile, const std::string& archiveFilePath);
-int RemoveFile(HANDLE hArchive, const std::string& archiveFilePath);
+int AddFiles(HANDLE hArchive, const std::string& inputPath, LCID preferredLocale);
+int AddFile(HANDLE hArchive, fs::path localFile, const std::string& archiveFilePath, LCID locale);
+int RemoveFile(HANDLE hArchive, const std::string& archiveFilePath, LCID locale);
 int ListFiles(HANDLE hHandle, const std::string &listfileName, bool listAll, bool listDetailed);
-char* ReadFile(HANDLE hArchive, const char *szFileName, unsigned int *fileSize);
+char* ReadFile(HANDLE hArchive, const char *szFileName, unsigned int *fileSize, LCID preferredLocale);
 void PrintMpqInfo(HANDLE hArchive, const std::string& infoProperty);
 uint32_t VerifyMpqArchive(HANDLE hArchive);
 int32_t PrintMpqSignature(HANDLE hArchive, std::string target);


### PR DESCRIPTION
Files in MPQs are referred to by not only their filename, but also their locale. So there can be multiple files with identical file names, where only the locale differs.

This PR adds locale support.

Closes #113.

Currently opening this PR as a Draft. Work remaining:
- [ ] Thorough tests
- [ ] Better output if an unknown locale is requested
- [ ] Update Readme