### PR TITLE
Locale support - create and add

### DIFF
--- a/src/mpq.cpp
+++ b/src/mpq.cpp
@@ -173,8 +173,6 @@ int AddFiles(HANDLE hArchive, const std::string& target, LCID locale) {
 }
 
 int AddFile(HANDLE hArchive, const fs::path& localFile, const std::string& archiveFilePath, LCID locale) {
-    std::cout << "[+] Adding file: " << archiveFilePath << std::endl;
-
     // Return if file doesn't exist on disk
     if (!fs::exists(localFile)) {
         std::cerr << "[!] File doesn't exist on disk: " << localFile << std::endl;


### PR DESCRIPTION
Locales are not supported in mpqcli, see #113. This PR adds locale support to the `create` and `add` subcommands.

This PR builds on top of #118, which in turn builds on top of #117.

Related PRs:
- #120 - Adding locale support to the `read` subcommand
- #121 - Adding locale support to the `extract` subcommand
- #122 - Adding locale support to the `remove` subcommand