### PR TITLE
Support unfamiliar locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Add a local file to an already existing MPQ archive.
 ```
 $ echo "For The Horde" > fth.txt
 $ mpqcli add fth.txt wow-patch.mpq
-[+] Adding file for locale 0: fth.txt
+[+] Adding file: fth.txt
 ```
 
 Alternatively, you can add a file to a specific subdirectory using the `-p` or `--path` argument.
@@ -165,7 +165,7 @@ Alternatively, you can add a file to a specific subdirectory using the `-p` or `
 ```
 $ echo "For The Alliance" > fta.txt
 $ mpqcli add fta.txt wow-patch.mpq --path texts
-[+] Adding file for locale 0: texts\fta.txt
+[+] Adding file: texts\fta.txt
 ```
 
 ### Add files to an MPQ archive with a given locale
@@ -174,7 +174,7 @@ Use the `--locale` argument to specify the locale that the added file will have 
 
 ```
 $ mpqcli add allianz.txt wow-patch.mpq --locale deDE
-[+] Adding file for locale 1031: allianz.txt
+[+] Adding file for locale deDE: allianz.txt
 ```
 
 ### Add a file with game-specific properties
@@ -183,7 +183,7 @@ Target a specific game version by using the `-g` or `--game` argument. This will
 
 ```
 $ mpqcli add khwhat1.wav archive.mpq --game wc2   # In StarCraft and WarCraft II MPQs, wav files are compressed in ADPCM form
-[+] Adding file for locale 0: khwhat1.wav
+[+] Adding file: khwhat1.wav
 ```
 
 
@@ -193,7 +193,7 @@ Remove a file from an existing MPQ archive.
 
 ```
 $ mpqcli remove fth.txt wow-patch.mpq
-[-] Removing file for locale 0: fth.txt
+[-] Removing file: fth.txt
 ```
 
 ### Remove a file from an MPQ archive with a given locale
@@ -202,7 +202,7 @@ Use the `--locale` argument to specify the locale of the file to be removed.
 
 ```
 $ mpqcli remove alianza.txt wow-patch.mpq --locale esES
-[-] Removing file for locale 1034: alianza.txt
+[-] Removing file for locale esES: alianza.txt
 ```
 
 

--- a/src/locales.h
+++ b/src/locales.h
@@ -11,14 +11,21 @@ const LCID defaultLocale = 0;
 
 std::string LocaleToLang(uint16_t locale);
 LCID LangToLocale(const std::string &lang);
+LCID ParseHexLocale(const std::string& str);
 std::vector<std::string> GetAllLocales();
+std::string PrettyPrintLocale(LCID locale, const std::string &prefix = "", bool alwaysPrint = false);
 
 // Validator for CLI11
 const inline auto LocaleValid = CLI::Validator(
         [](const std::string &str) {
             if (str == "default") return std::string();
 
-            LCID locale = LangToLocale(str);
+            // Check if it's a 4-character hexadecimal string
+            if (ParseHexLocale(str) != defaultLocale) {
+                return std::string();
+            }
+
+            const LCID locale = LangToLocale(str);
             if (locale == 0) {
                 std::string validLocales = "Locale must be nothing, or one of:";
                 for (const auto& l : GetAllLocales()) {
@@ -28,7 +35,7 @@ const inline auto LocaleValid = CLI::Validator(
             }
             return std::string();
         },
-        "Validates locales and outputs valid locales",
+        "",
         "LocaleValidator"
 );
 

--- a/src/mpq.cpp
+++ b/src/mpq.cpp
@@ -200,13 +200,13 @@ int AddFile(
     if (SFileOpenFileEx(hArchive, archiveFilePath.c_str(), SFILE_OPEN_FROM_MPQ, &hFile)) {
         int32_t fileLocale = GetFileInfo<int32_t>(hFile, SFileInfoLocale);
         if (fileLocale == locale) {
-            std::cerr << "[!] File for locale " << locale << " already exists in MPQ archive: " << archiveFilePath
+            std::cerr << "[!] File" << PrettyPrintLocale(locale, " for locale ") << " already exists in MPQ archive: " << archiveFilePath
                       << " - Skipping..." << std::endl;
             return -1;
         }
     }
     SFileCloseFile(hFile);
-    std::cout << "[+] Adding file for locale " << locale << ": " << archiveFilePath << std::endl;
+    std::cout << "[+] Adding file" << PrettyPrintLocale(locale, " for locale ") << ": " << archiveFilePath << std::endl;
 
     // Verify that we are not exceeding maxFile size of the archive, and if we do, increase it
     int32_t numberOfFiles = GetFileInfo<int32_t>(hArchive, SFileMpqNumberOfFiles);
@@ -254,15 +254,15 @@ int AddFile(
 
 int RemoveFile(HANDLE hArchive, const std::string& archiveFilePath, LCID locale) {
     SFileSetLocale(locale);
-    std::cout << "[-] Removing file for locale " << locale <<": " << archiveFilePath << std::endl;
+    std::cout << "[-] Removing file" << PrettyPrintLocale(locale, " for locale ") <<": " << archiveFilePath << std::endl;
 
     if (!SFileHasFile(hArchive, archiveFilePath.c_str())) {
-        std::cerr << "[!] Failed: File doesn't exist for locale " << locale << ": " << archiveFilePath << std::endl;
+        std::cerr << "[!] Failed: File doesn't exist" << PrettyPrintLocale(locale, " for locale ") << ": " << archiveFilePath << std::endl;
         return -1;
     }
 
     if (!SFileRemoveFile(hArchive, archiveFilePath.c_str(), 0)) {
-        std::cerr << "[!] Failed: File cannot be removed for locale " << locale << ": " << archiveFilePath << std::endl;
+        std::cerr << "[!] Failed: File cannot be removed" << PrettyPrintLocale(locale, " for locale ") << ": " << archiveFilePath << std::endl;
         return -1;
     }
 

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -74,7 +74,7 @@ def test_add_file_to_mpq_archive(binary_path, generate_test_files):
 
     output_lines = set(result.stdout.splitlines())
     expected_stdout_output = {
-        "[+] Adding file for locale 0: test.txt",
+        "[+] Adding file: test.txt",
     }
     assert output_lines == expected_stdout_output, f"Unexpected output: {output_lines}"
 
@@ -165,7 +165,7 @@ def test_create_mpq_with_locale(binary_path, generate_test_files):
 
     output_lines = set(result.stdout.splitlines())
     expected_stdout_output = {
-        "[+] Adding file for locale 1034: cats.txt",
+        "[+] Adding file for locale esES: cats.txt",
     }
     assert output_lines == expected_stdout_output, f"Unexpected output: {output_lines}"
 
@@ -227,7 +227,7 @@ def test_add_file_with_game_profile(binary_path, generate_test_files):
 
         assert result.returncode == 0, f"mpqcli failed for profile {profile}: {result.stderr}"
         assert f"Using game profile: {profile}" in result.stdout, f"Game profile message not found for {profile}"
-        assert f"Adding file for locale 0: test_{profile}.txt" in result.stdout
+        assert f"Adding file: test_{profile}.txt" in result.stdout
 
         # Verify compression flags on the added file
         list_result = subprocess.run(

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -141,21 +141,23 @@ def test_list_mpq_with_weak_signature(binary_path):
     assert output_lines == expected_output, f"Unexpected output: {output_lines}"
 
 
-def test_list_mpq_without_providing_listfile(binary_path):
+def test_list_mpq_without_providing_listfile(binary_path, generate_mpq_without_internal_listfile):
     """
     Test MPQ file listing of MPQ that contains no internal listfile.
 
     This test checks:
     - That handling MPQs with no internal listfile generates the expected output.
     """
+    _ = generate_mpq_without_internal_listfile
     script_dir = Path(__file__).parent
-    test_file = script_dir / "data" / "mpq_without_internal_listfile.mpq"
+    test_file = script_dir / "data" / "mpq_without_internal_listfile2.mpq"
 
     ## No flags
     expected_output = {
         "File00000000.xxx",
         "File00000001.xxx",
         "File00000002.xxx",
+        "File00000003.xxx",
     }
     result = subprocess.run(
         [str(binary_path), "list", str(test_file)],
@@ -173,6 +175,7 @@ def test_list_mpq_without_providing_listfile(binary_path):
         "File00000000.xxx",
         "File00000001.xxx",
         "File00000002.xxx",
+        "File00000003.xxx",
     }
     result = subprocess.run(
         [str(binary_path), "list", "-a", str(test_file)],
@@ -186,11 +189,21 @@ def test_list_mpq_without_providing_listfile(binary_path):
     assert output_lines == expected_output, f"Unexpected output: {output_lines}"
 
     ## --all, --detailed flag
-    expected_output = {
-        "      27 enUS                      File00000000.xxx",
-        "      27 enUS                      File00000001.xxx",
-        "      72 enUS                      File00000002.xxx",
-    }
+    if platform.system() != "Windows":
+        expected_output = {
+            "      31 enUS                      File00000000.xxx",
+            "      33 deDE                      File00000001.xxx",
+            "      27 041D                      File00000002.xxx",
+            "      72 enUS                      File00000003.xxx",
+        }
+    else:
+        expected_output = {
+            "      31 enUS                      File00000000.xxx",
+            "      32 deDE                      File00000001.xxx",
+            "      26 041D                      File00000002.xxx",
+            "      72 enUS                      File00000003.xxx",
+        }
+
     result = subprocess.run(
         [str(binary_path), "list", "-ad", str(test_file)],
         stdout=subprocess.PIPE,
@@ -203,7 +216,7 @@ def test_list_mpq_without_providing_listfile(binary_path):
     assert output_lines == expected_output, f"Unexpected output: {output_lines}"
 
 
-def test_list_mpq_providing_partial_external_listfile(binary_path):
+def test_list_mpq_providing_partial_external_listfile(binary_path, generate_mpq_without_internal_listfile):
     """
     Test MPQ file listing of MPQ that contains no internal listfile, when providing a partially compete external listfile.
 
@@ -212,14 +225,16 @@ def test_list_mpq_providing_partial_external_listfile(binary_path):
     - That providing a partially complete external listfile shows the files it lists.
     - That the files not listed in the external listfile still show up in the output.
     """
+    _ = generate_mpq_without_internal_listfile
     script_dir = Path(__file__).parent
-    test_file = script_dir / "data" / "mpq_without_internal_listfile.mpq"
+    test_file = script_dir / "data" / "mpq_without_internal_listfile2.mpq"
     listfile = script_dir / "data" / "listfile.txt"
     listfile.write_text("cats.txt")
 
     ## No flags
     expected_output = {
         "File00000000.xxx",
+        "File00000002.xxx",
         "cats.txt",
     }
     result = subprocess.run(
@@ -236,6 +251,7 @@ def test_list_mpq_providing_partial_external_listfile(binary_path):
     ## --all flag
     expected_output = {
         "File00000000.xxx",
+        "File00000002.xxx",
         "cats.txt",
         "(signature)",
     }
@@ -251,11 +267,20 @@ def test_list_mpq_providing_partial_external_listfile(binary_path):
     assert output_lines == expected_output, f"Unexpected output: {output_lines}"
 
     ## --all, --detailed flag
-    expected_output = {
-        "      27 enUS                      File00000000.xxx",
-        "      27 enUS                      cats.txt",
-        "      72 enUS                      (signature)",
-    }
+    if platform.system() != "Windows":
+        expected_output = {
+            "      31 enUS                      File00000000.xxx",
+            "      27 041D                      File00000002.xxx",
+            "      33 deDE                      cats.txt",
+            "      72 enUS                      (signature)",
+        }
+    else:
+        expected_output = {
+            "      31 enUS                      File00000000.xxx",
+            "      26 041D                      File00000002.xxx",
+            "      32 deDE                      cats.txt",
+            "      72 enUS                      (signature)",
+        }
     result = subprocess.run(
         [str(binary_path), "list", "-ad", str(test_file), "--listfile", str(listfile)],
         stdout=subprocess.PIPE,
@@ -268,7 +293,7 @@ def test_list_mpq_providing_partial_external_listfile(binary_path):
     assert output_lines == expected_output, f"Unexpected output: {output_lines}"
 
 
-def test_list_mpq_providing_complete_external_listfile(binary_path):
+def test_list_mpq_providing_complete_external_listfile(binary_path, generate_mpq_without_internal_listfile):
     """
     Test MPQ file listing of MPQ that contains no internal listfile, when providing a compete external listfile.
 
@@ -276,15 +301,17 @@ def test_list_mpq_providing_complete_external_listfile(binary_path):
     - That handling MPQs with no internal listfile generates the expected output.
     - That providing a complete external listfile shows the files it lists.
     """
+    _ = generate_mpq_without_internal_listfile
     script_dir = Path(__file__).parent
-    test_file = script_dir / "data" / "mpq_without_internal_listfile.mpq"
+    test_file = script_dir / "data" / "mpq_without_internal_listfile2.mpq"
     listfile = script_dir / "data" / "listfile.txt"
-    listfile.write_text("cats.txt\ndogs.txt")
+    listfile.write_text("cats.txt\ndogs.txt\ncapybaras.txt")
 
     ## No flags
     expected_output = {
         "dogs.txt",
         "cats.txt",
+        "capybaras.txt",
     }
     result = subprocess.run(
         [str(binary_path), "list", str(test_file), "--listfile", str(listfile)],
@@ -301,6 +328,7 @@ def test_list_mpq_providing_complete_external_listfile(binary_path):
     expected_output = {
         "dogs.txt",
         "cats.txt",
+        "capybaras.txt",
         "(signature)",
     }
     result = subprocess.run(
@@ -315,11 +343,21 @@ def test_list_mpq_providing_complete_external_listfile(binary_path):
     assert output_lines == expected_output, f"Unexpected output: {output_lines}"
 
     ## --all, --detailed flag
-    expected_output = {
-        "      27 enUS                      dogs.txt",
-        "      27 enUS                      cats.txt",
-        "      72 enUS                      (signature)",
-    }
+    if platform.system() != "Windows":
+        expected_output = {
+            "      31 enUS                      capybaras.txt",
+            "      33 deDE                      cats.txt",
+            "      27 041D                      dogs.txt",
+            "      72 enUS                      (signature)",
+        }
+    else:
+        expected_output = {
+            "      31 enUS                      capybaras.txt",
+            "      32 deDE                      cats.txt",
+            "      26 041D                      dogs.txt",
+            "      72 enUS                      (signature)",
+        }
+
     result = subprocess.run(
         [str(binary_path), "list", "-ad", str(test_file), "--listfile", str(listfile)],
         stdout=subprocess.PIPE,

--- a/test/test_remove.py
+++ b/test/test_remove.py
@@ -45,13 +45,13 @@ def test_remove_target_file_does_not_exist(binary_path, generate_locales_mpq_tes
 
     output_lines = set(result.stdout.splitlines())
     expected_stdout_output = {
-        "[-] Removing file for locale 0: does-not-exist.txt",
+        "[-] Removing file: does-not-exist.txt",
     }
     assert output_lines == expected_stdout_output, f"Unexpected output: {output_lines}"
 
     output_lines = set(result.stderr.splitlines())
     expected_stderr_output = {
-        "[!] Failed: File doesn't exist for locale 0: does-not-exist.txt",
+        "[!] Failed: File doesn't exist: does-not-exist.txt",
     }
     assert output_lines == expected_stderr_output, f"Unexpected output: {output_lines}"
 
@@ -79,7 +79,7 @@ def test_remove_file_from_mpq_archive(binary_path, generate_locales_mpq_test_fil
 
     output_lines = set(result.stdout.splitlines())
     expected_output = {
-        "[-] Removing file for locale 0: cats.txt",
+        "[-] Removing file: cats.txt",
     }
     assert output_lines == expected_output, f"Unexpected output: {output_lines}"
 
@@ -106,6 +106,7 @@ def test_remove_file_with_locale_from_mpq_archive(binary_path, generate_locales_
         "enUS  cats.txt",
         "deDE  cats.txt",
         "esES  cats.txt",
+        "041D  cats.txt",
     }
     verify_archive_content(binary_path, target_file, expected_output)
 
@@ -121,6 +122,7 @@ def test_remove_file_with_locale_from_mpq_archive(binary_path, generate_locales_
     expected_output = {
         "deDE  cats.txt",
         "esES  cats.txt",
+        "041D  cats.txt",
     }
     verify_archive_content(binary_path, target_file, expected_output)
 
@@ -135,6 +137,7 @@ def test_remove_file_with_locale_from_mpq_archive(binary_path, generate_locales_
 
     expected_output = {
         "deDE  cats.txt",
+        "041D  cats.txt",
     }
     verify_archive_content(binary_path, target_file, expected_output)
 


### PR DESCRIPTION
In this PR:

- Support for listing unfamiliar locales
- Better printing of locales (will not print the default locale in most cases)
- Correcting Portuguese locale
- The tests will now make their own MPQ without an internal listfile.