### PR TITLE
Add returns error codes

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -99,6 +99,7 @@ int HandleCreate(const std::string &target, const std::optional<std::string> &na
     uint32_t fileCount = CalculateMpqMaxFileValue(target);
 
     // Create the MPQ archive and add files
+    int result = 0;
     HANDLE hArchive = CreateMpqArchive(outputFile, fileCount, gameRules);
     if (hArchive) {
         LCID lcid = locale.has_value() ? LangToLocale(locale.value()) : defaultLocale;
@@ -119,9 +120,9 @@ int HandleCreate(const std::string &target, const std::optional<std::string> &na
                 filePath = fs::path(nameInArchive.value());
                 archivePath = WindowsifyFilePath(filePath);  // Normalise path for MPQ
             }
-            AddFile(hArchive, target, archivePath, lcid, gameRules, addOverrides);
+            result |= AddFile(hArchive, target, archivePath, lcid, gameRules, addOverrides);
         } else {
-            AddFiles(hArchive, target, "", lcid, gameRules, addOverrides);
+            result |= AddFiles(hArchive, target, "", lcid, gameRules, addOverrides);
         }
         if (signArchive) {
             SignMpqArchive(hArchive);
@@ -132,7 +133,7 @@ int HandleCreate(const std::string &target, const std::optional<std::string> &na
         return 1;
     }
 
-    return 0;
+    return result;
 }
 
 int HandleAdd(const std::vector<std::string> &files, const std::string &target,
@@ -201,6 +202,7 @@ int HandleAdd(const std::vector<std::string> &files, const std::string &target,
                   << std::endl;
     }
 
+    int result = 0;
     for (const auto &f : files) {
         if (!fs::exists(f)) {
             std::cerr << "[!] Path does not exist: " << f << std::endl;
@@ -209,7 +211,9 @@ int HandleAdd(const std::vector<std::string> &files, const std::string &target,
 
         if (fs::is_directory(f)) {
             std::string prefix = path.value_or("");
-            AddFiles(hArchive, f, prefix, lcid, gameRules, addOverrides, overwrite, update);
+            result |=
+                AddFiles(hArchive, f, prefix, lcid, gameRules, addOverrides, overwrite, update);
+
         } else if (fs::is_regular_file(f)) {
             fs::path filePath = fs::path(f);
             std::string archivePath = filePath.filename().u8string();
@@ -225,14 +229,15 @@ int HandleAdd(const std::vector<std::string> &files, const std::string &target,
                 archivePath = WindowsifyFilePath(filePath);
             }
 
-            AddFile(hArchive, f, archivePath, lcid, gameRules, addOverrides, overwrite);
+            result |= AddFile(hArchive, f, archivePath, lcid, gameRules, addOverrides, overwrite);
+
         } else {
             std::cerr << "[!] Not a file or directory: " << f << std::endl;
         }
     }
 
     CloseMpqArchive(hArchive);
-    return 0;
+    return result;
 }
 
 int HandleRemove(const std::vector<std::string> &files, const std::string &target,

--- a/src/mpq.cpp
+++ b/src/mpq.cpp
@@ -197,6 +197,7 @@ int AddFiles(HANDLE hArchive, const std::string &inputPath, const std::string &p
 
     int filesAdded = 0;
     int filesSkipped = 0;
+    int filesFailed = 0;
 
     for (const auto &entry : entries) {
         fs::path inputFilePath = fs::relative(entry, targetPath);
@@ -235,19 +236,22 @@ int AddFiles(HANDLE hArchive, const std::string &inputPath, const std::string &p
             }
         }
 
-        int result = AddFile(hArchive, entry.path(), archiveFilePath, locale, gameRules, overrides,
-                             overwrite);
+        const int result = AddFile(hArchive, entry.path(), archiveFilePath, locale, gameRules,
+                                   overrides, overwrite);
         if (result == 0) {
             filesAdded++;
+        } else {
+            filesFailed++;
         }
     }
 
     if (update) {
-        std::cout << "[*] " << filesAdded << " files added, " << filesSkipped << " files skipped"
+        std::cout << "[*] For " << inputPath << ": " << filesAdded << " files added, "
+                  << filesSkipped << " files skipped, " << filesFailed << " files failed."
                   << std::endl;
     }
 
-    return 0;
+    return filesFailed;
 }
 
 int AddFile(HANDLE hArchive, const fs::path &localFile, const std::string &archiveFilePath,
@@ -256,7 +260,7 @@ int AddFile(HANDLE hArchive, const fs::path &localFile, const std::string &archi
     // Return if file doesn't exist on disk
     if (!fs::exists(localFile)) {
         std::cerr << "[!] File doesn't exist on disk: " << localFile << std::endl;
-        return -1;
+        return 1;
     }
 
     // Check if file exists in MPQ archive
@@ -269,7 +273,7 @@ int AddFile(HANDLE hArchive, const fs::path &localFile, const std::string &archi
             std::cerr << "[!] File" << PrettyPrintLocale(locale, " for locale ")
                       << " already exists in MPQ archive: " << archiveFilePath << " - Skipping..."
                       << std::endl;
-            return -1;
+            return 1;
         } else if (fileLocale == locale) {
             std::cout << "[+] File" << PrettyPrintLocale(locale, " for locale ")
                       << " already exists in MPQ archive: " << archiveFilePath
@@ -290,7 +294,7 @@ int AddFile(HANDLE hArchive, const fs::path &localFile, const std::string &archi
             int32_t error = SErrGetLastError();
             std::cerr << "[!] Error: " << error
                       << " Failed to increase new max file count to: " << newMaxFiles << std::endl;
-            return -1;
+            return 1;
         }
     }
 
@@ -323,7 +327,7 @@ int AddFile(HANDLE hArchive, const fs::path &localFile, const std::string &archi
     if (!addedFile) {
         int32_t error = SErrGetLastError();
         std::cerr << "[!] Error: " << error << " Failed to add: " << archiveFilePath << std::endl;
-        return -1;
+        return 1;
     }
 
     return 0;

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -231,7 +231,7 @@ def test_add_existing_file_without_overwrite_should_fail(binary_path, generate_t
     }
     assert output_lines == expected_stderr_output, f"Unexpected output: {output_lines}"
 
-    assert result.returncode == 0, f"mpqcli failed with error: {result.stderr}"
+    assert result.returncode == 1, f"mpqcli failed with error: {result.stderr}"
 
     verify_file_in_mpq_has_content(binary_path, target_file, "cats.txt", expected_content)
 
@@ -719,7 +719,7 @@ def test_add_directory_without_overwrite_skips_existing(binary_path, generate_te
             text=True
         )
 
-        assert result.returncode == 0, f"mpqcli failed with error: {result.stderr}"
+        assert result.returncode == 1, f"mpqcli failed with error: {result.stderr}"
         assert "[!] File already exists in MPQ archive: cats.txt - Skipping..." in result.stderr
 
         verify_file_in_mpq_has_content(binary_path, target_mpq, "cats.txt", original_content)
@@ -871,7 +871,7 @@ def test_add_update_single_file_emits_warning(binary_path, generate_test_files):
         text=True
     )
 
-    assert result.returncode == 0, f"mpqcli failed with error: {result.stderr}"
+    assert result.returncode == 1, f"mpqcli failed with error: {result.stderr}"
     assert "--update is only meaningful when adding a directory" in result.stderr
 
 


### PR DESCRIPTION
With this change, any errors when adding files propagates outwards, so mpqcli now returns 1 when failing to add files.