### PR TITLE
Fixing memory leak in Read subcommand

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -301,6 +301,7 @@ int HandleRead(const std::string &file, const std::string &target,
     uint32_t fileSize;
     auto fileContent = ReadFile(hArchive, file.c_str(), &fileSize, lcid);
     if (!fileContent) {
+        CloseMpqArchive(hArchive);
         return 1;
     }
 


### PR DESCRIPTION
I found this memory leak using the Valgrind setup from #146. Before merging this PR, would you mind giving #146 another look - I figure it's useful to see that PR failing because memory leaks are present :)

I also found a memory leak in StormLib, which I fixed [here](https://github.com/ladislav-zezula/StormLib/pull/434). We should thus bump the StormLib version used in mpqcli.